### PR TITLE
QOL Changes

### DIFF
--- a/spoly.lua
+++ b/spoly.lua
@@ -75,6 +75,7 @@ function spoly.Render(id, funcDraw)
 
     render.PushRenderTarget(RT)
 
+        render.SetWriteDepthToDestAlpha(false)
         render.Clear(0, 0, 0, 0)
 
         cam.Start2D()

--- a/spoly.lua
+++ b/spoly.lua
@@ -74,9 +74,9 @@ function spoly.Render(id, funcDraw)
     spoly.status = STATUS_BUSY
 
     render.PushRenderTarget(RT)
-    
+
         render.Clear(0, 0, 0, 0)
-        
+
         cam.Start2D()
             surface.SetDrawColor(color_white)
             draw.NoTexture()
@@ -87,7 +87,7 @@ function spoly.Render(id, funcDraw)
 
         file.Delete(path)
         file.Write(path, content)
-    
+
     render.PopRenderTarget()
 
     materials[id] = Material('data/' .. path, 'mips')
@@ -107,7 +107,7 @@ end
 function spoly.Generate(id, funcDraw)
     assert(isstring(id), Format('bad argument #1 to \'spoly.Generate\' (expected string, got %s)', type(id)))
     assert(isfunction(funcDraw), Format('bad argument #2 to \'spoly.Generate\' (expected function, got %s)', type(funcDraw)))
-    
+
     if (materials[id]) then return end
     if (queued[id]) then return end
 
@@ -133,9 +133,9 @@ do
     hook.Add('Think', 'spoly.QueueController', function()
         if (spoly.status == STATUS_IDLE and queue[1] and nextThink <= CurTime()) then
             nextThink = CurTime() + thinkRate
-    
+
             local data = table.remove(queue, 1)
-    
+
             spoly.Render(data.id, data.funcDraw)
         end
     end)
@@ -156,18 +156,18 @@ do
     function spoly.Draw(id, x, y, w, h, color)
         local material = materials[id]
         if (not material) then return end
-    
+
         if (color) then
             SetDrawColor(color)
         end
-    
+
         SetMaterial(material)
-        
+
         PushFilterMag(TEXFILTER.ANISOTROPIC)
         PushFilterMin(TEXFILTER.ANISOTROPIC)
-    
+
         DrawTexturedRect(x, y, w, h)
-    
+
         PopFilterMag()
         PopFilterMin()
     end
@@ -175,18 +175,18 @@ do
     function spoly.DrawRotated(id, x, y, w, h, rotation, color)
         local material = materials[id]
         if (not material) then return end
-    
+
         if (color) then
             SetDrawColor(color)
         end
-    
+
         SetMaterial(material)
-        
+
         PushFilterMag(TEXFILTER.ANISOTROPIC)
         PushFilterMin(TEXFILTER.ANISOTROPIC)
-    
+
         DrawTexturedRectRotated(x, y, w, h, rotation)
-    
+
         PopFilterMag()
         PopFilterMin()
     end

--- a/spoly.lua
+++ b/spoly.lua
@@ -84,7 +84,12 @@ function spoly.Render(id, funcDraw)
             local success, errorText = pcall(funcDraw, SIZE, SIZE)
         cam.End2D()
 
-        local content = render.Capture(CAPTURE_DATA)
+        local capture_data = CAPTURE_DATA
+        if success and errorText then
+            capture_data = errorText
+        end
+
+        local content = render.Capture(capture_data)
 
         file.Delete(path)
         file.Write(path, content)

--- a/spoly.lua
+++ b/spoly.lua
@@ -134,6 +134,12 @@ do
         if (spoly.status == STATUS_IDLE and queue[1] and nextThink <= CurTime()) then
             nextThink = CurTime() + thinkRate
 
+            -- if game ui is visible, hide it, as render.Capture won't work if it's visible
+            if (gui.IsGameUIVisible()) then
+                gui.HideGameUI()
+                return
+            end
+
             local data = table.remove(queue, 1)
 
             spoly.Render(data.id, data.funcDraw)


### PR DESCRIPTION
### Quality of Life Improvements

Hey there! Thank you for your amazing work! This PR introduces several small quality-of-life improvements to the PNG capture process:

#### Changes:
1. **Hide Game UI Before Capturing**  
   Ensures the game UI is hidden before capturing, preventing random failures in PNG generation and guaranteeing valid files.

2. **Set `render.SetWriteDepthToDestAlpha` to `false`**  
   This change avoids the possibility of generating corrupted PNG files, even though this issue hasn't been observed directly.

3. **Allow Custom Capture Data Return**  
   Enables returning custom capture data when rendering, providing more flexibility for specific use cases.

I have done a small change too on my version, which doesn't write the contents of the png to the main file id till it's sure that the material is not an error, because gmod refuses to load a materal from a file if it was corrupted. So it writes to a tmp file, if it's valid, writes to the main file. I can include it in this PR if you would like it!